### PR TITLE
Use alpine 3.8 w/ ansible 2.5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM alpine:3.4
-RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main">>/etc/apk/repositories && \
-    apk update && \
-    apk add ansible@edge curl openssh-client bash git
+FROM alpine:3.8
+RUN apk update && \
+    apk add ansible curl openssh-client bash git
 ADD prom-run /
 ENTRYPOINT /prom-run


### PR DESCRIPTION
weaveworks/service-conf#2773 is currently generating an ansible diff because

```
New in version 2.3: The name: keyword for block: was added in Ansible 2.3.
```