### PR TITLE
Use ansible 2.7.0 from edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.8
-RUN apk update && \
-    apk add ansible curl openssh-client bash git
+RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main">>/etc/apk/repositories && \
+    apk add --no-cache ansible@edge curl openssh-client bash git
 ADD prom-run /
 ENTRYPOINT /prom-run


### PR DESCRIPTION
weaveworks/service-conf#2773 is currently generating an ansible diff because

```
TASK [disk : format EBS volumes] ***********************************************
fatal: [ec2-107-22-42-249.compute-1.amazonaws.com]: FAILED! => {"msg": "Invalid data passed to 'loop', it requires a list, got this instead: dict_items([]). Hint: If you passed a list/dict of just one element, try adding wantlist=True to your lookup invocation or use q/query instead of lookup."}
```