### PR TITLE
Return to ansible 2.5.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine:3.8
-RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main">>/etc/apk/repositories && \
-    apk add --no-cache ansible@edge curl openssh-client bash git
+RUN apk add --no-cache ansible curl openssh-client bash git
 ADD prom-run /
 ENTRYPOINT /prom-run


### PR DESCRIPTION
The spurious diff was caused by differing python version; the correct fix is a modification to the template in the playbooks.